### PR TITLE
Use boolean for TLS ssl config

### DIFF
--- a/bumper/mqttserver.py
+++ b/bumper/mqttserver.py
@@ -197,7 +197,7 @@ class MQTTServer:
                     "default": {"type": "tcp"},
                     "tls1": {
                         "bind": "{}:{}".format(address[0], address[1]),
-                        "ssl": "on",
+                        "ssl": True,
                         "certfile": bumper.server_cert,
                         "keyfile": bumper.server_key,
                     },


### PR DESCRIPTION
## Summary
- use boolean in TLS listener configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a476d16e288320a442ea56e263f7f5