### PR TITLE
Handle BrokerError from amqtt

### DIFF
--- a/bumper/mqttserver.py
+++ b/bumper/mqttserver.py
@@ -7,6 +7,7 @@ import amqtt
 from amqtt.broker import Broker
 from amqtt.client import MQTTClient
 from amqtt.mqtt.constants import QOS_0, QOS_1, QOS_2
+from amqtt.errors import BrokerError
 import pkg_resources
 import time
 import bumper
@@ -155,7 +156,7 @@ class MQTTServer:
         try:
             await self.broker.start()
 
-        except amqtt.broker.BrokerException as e:
+        except BrokerError as e:
             mqttserverlog.exception(e)
             #asyncio.create_task(bumper.shutdown())
             pass


### PR DESCRIPTION
## Summary
- import `BrokerError` from `amqtt.errors`
- handle `BrokerError` in `MQTTServer.broker_coro`

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after tests report 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a476d280088320809e3d7e4a9068c5