### PR TITLE
Guard ConfServer shutdown on missing runner

### DIFF
--- a/bumper/confserver.py
+++ b/bumper/confserver.py
@@ -162,7 +162,8 @@ class ConfServer:
 
     async def stop_server(self):
         try:
-            await self.runner.shutdown()
+            if self.runner:
+                await self.runner.shutdown()
 
         except Exception as e:
             confserverlog.exception("{}".format(e))


### PR DESCRIPTION
## Summary
- avoid shutdown error when ConfServer runner is missing

## Testing
- `pytest` *(fails: ValueError: Unknown argument type: <class 'function'>)*

------
https://chatgpt.com/codex/tasks/task_e_68a476d7fd588320aea7075192bebb73