### PR TITLE
Guard shutdown against missing MQTT broker

### DIFF
--- a/bumper/__init__.py
+++ b/bumper/__init__.py
@@ -275,14 +275,15 @@ async def shutdown():
 
         await conf_server.stop_server()
         await conf_server_2.stop_server()
-        if mqtt_server.broker.transitions.state == "started":
-            await mqtt_server.broker.shutdown()
-        elif mqtt_server.broker.transitions.state == "starting":
-            while mqtt_server.broker.transitions.state == "starting":
-                await asyncio.sleep(0.1)
+        if mqtt_server and mqtt_server.broker:
             if mqtt_server.broker.transitions.state == "started":
                 await mqtt_server.broker.shutdown()
-                await mqtt_helperbot.Client.disconnect()
+            elif mqtt_server.broker.transitions.state == "starting":
+                while mqtt_server.broker.transitions.state == "starting":
+                    await asyncio.sleep(0.1)
+                if mqtt_server.broker.transitions.state == "started":
+                    await mqtt_server.broker.shutdown()
+                    await mqtt_helperbot.Client.disconnect()
         if xmpp_server.server:
             if xmpp_server.server._serving:
                 xmpp_server.server.close()


### PR DESCRIPTION
## Summary
- avoid attribute errors when shutting down without an MQTT broker

## Testing
- `pytest` *(fails: ValueError: Unknown argument type: <class 'function'>, AttributeError: module 'amqtt.broker' has no attribute 'BrokerException', AttributeError: 'Transport' object attribute 'get_extra_info' is read-only, AttributeError: property '_stream_reader' of 'StreamReaderProtocol' object has no setter)*

------
https://chatgpt.com/codex/tasks/task_e_68a476de37ec8320b826fd48dc397ee3