### PR TITLE
Fix MQTT helperbot authentication loop

### DIFF
--- a/tests/test_mqtt_helperbot.py
+++ b/tests/test_mqtt_helperbot.py
@@ -1,0 +1,14 @@
+import asyncio
+import bumper
+import pytest
+
+@pytest.mark.asyncio
+async def test_helperbot_connects():
+    address = ("127.0.0.1", 8885)
+    server = bumper.MQTTServer(address, password_file="tests/passwd")
+    await server.broker_coro()
+    helperbot = bumper.MQTTHelperBot(address)
+    await helperbot.start_helper_bot()
+    assert helperbot.Client.session.transitions.state == "connected"
+    await helperbot.Client.disconnect()
+    await server.broker.shutdown()


### PR DESCRIPTION
## Summary
- rely solely on custom BumperMQTTServer auth plugin to avoid conflicting anonymous/file auth
- broaden helperbot MQTT subscriptions and guard against missing global helperbot instance
- add regression test ensuring helperbot can establish a connection

## Testing
- `pytest tests/test_mqtt_helperbot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a49c02d6bc8320b4c6b87d5259b4eb