### PR TITLE
Expose MQTT TLS listener publicly by default

### DIFF
--- a/bumper/__init__.py
+++ b/bumper/__init__.py
@@ -47,12 +47,11 @@ server_cert = os.environ.get("BUMPER_CERT") or os.path.join(certs_dir, "bumper.c
 server_key = os.environ.get("BUMPER_KEY") or os.path.join(certs_dir, "bumper.key")
 
 # Listeners
-bumper_listen = os.environ.get("BUMPER_LISTEN") or socket.gethostbyname(
-    socket.gethostname()
-)
+host_ip = socket.gethostbyname(socket.gethostname())
+bumper_listen = os.environ.get("BUMPER_LISTEN") or "0.0.0.0"
 
 
-bumper_announce_ip = os.environ.get("BUMPER_ANNOUNCE_IP") or bumper_listen
+bumper_announce_ip = os.environ.get("BUMPER_ANNOUNCE_IP") or host_ip
 
 # Other
 bumper_debug = strtobool(os.environ.get("BUMPER_DEBUG")) or False
@@ -229,7 +228,8 @@ async def start():
     global mqtt_server
     mqtt_server = MQTTServer((bumper_listen, mqtt_listen_port))
     global mqtt_helperbot
-    mqtt_helperbot = MQTTHelperBot((bumper_listen, mqtt_listen_port))
+    helperbot_host = bumper_listen if bumper_listen != "0.0.0.0" else "127.0.0.1"
+    mqtt_helperbot = MQTTHelperBot((helperbot_host, mqtt_listen_port))
     global conf_server
     conf_server = ConfServer((bumper_listen, conf1_listen_port), usessl=True)
     global conf_server_2

--- a/docs/Env_Var.md
+++ b/docs/Env_Var.md
@@ -1,15 +1,16 @@
 # Environment Variables
 
-Bumper has a number of environment variables to help with custom deployments and configuration.  These should be set prior to executing Bumper.
+Bumper has a number of environment variables to help with custom deployments and configuration. These should be set prior to executing Bumper.
 
-| Setting            | Value                              | Description                                                                                                                 |
-| ------------------ | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| BUMPER_LISTEN      | {ipv4 address}                     | IP address to start server listeners on                                                                                     |
-| BUMPER_ANNOUNCE_IP | {ipv4 address}                     | IP address to tell bots when they request the server location.  May need to be set in cases such as when LISTEN is 0.0.0.0. |
-| BUMPER_CA          | {full path to ca.crt location}     | The public CA certificate (ca.crt) to be loaded                                                                             |
-| BUMPER_CERT        | {full path to bumper.crt location} | The public server certificate (bumper.crt) to be used by the Bumper server                                                  |
-| BUMPER_KEY         | {full path to bumper.key location} | The private server key (bumper.key) to be used by the Bumper server                                                         |
-| BUMPER_LOGS        | {full path to logs directory}      | The directory where logs should be stored                                                                                   |
-| BUMPER_DATA        | {full path to data directory}      | The directory where persistent data should be stored (bumper.db)                                                            |
-| BUMPER_DEBUG       | true                               | Run Bumper with debug mode/logging                                                                                          |
-| LOG_TO_STDOUT      | true                               | Instead of logging to logs/, logs to to STDOUT |
+| Setting            | Value                              | Description |
+| ------------------ | ---------------------------------- | --------------------------------------------------------------------- |
+| BUMPER_LISTEN      | {ipv4 address}                     | IP address to start server listeners on (default: 0.0.0.0) |
+| BUMPER_ANNOUNCE_IP | {ipv4 address}                     | IP address announced to bots. Defaults to host IP; set if LISTEN is 0.0.0.0. |
+| BUMPER_CA          | {full path to ca.crt location}     | The public CA certificate (ca.crt) to be loaded |
+| BUMPER_CERT        | {full path to bumper.crt location} | The public server certificate (bumper.crt) to be used by the Bumper server |
+| BUMPER_KEY         | {full path to bumper.key location} | The private server key (bumper.key) to be used by the Bumper server |
+| BUMPER_LOGS        | {full path to logs directory}      | The directory where logs should be stored |
+| BUMPER_DATA        | {full path to data directory}      | The directory where persistent data should be stored (bumper.db) |
+| BUMPER_DEBUG       | true                               | Run Bumper with debug mode/logging |
+| LOG_TO_STDOUT      | true                               | Instead of logging to logs/, logs to STDOUT |
+


### PR DESCRIPTION
## Summary
- default to listening on all interfaces and announce host IP
- ensure internal helper bot connects via localhost when binding to 0.0.0.0
- document default BUMPER_LISTEN behavior and announce IP guidance

## Testing
- `pytest` *(fails: ValueError: Unknown argument type...)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a4ef859483209c99bf5d90149ded